### PR TITLE
osmosis big project queries

### DIFF
--- a/sql/activity/osmosis/activity_stats.sql
+++ b/sql/activity/osmosis/activity_stats.sql
@@ -1,0 +1,58 @@
+WITH base_stats AS (
+    SELECT
+        DISTINCT tx_from AS user_address,
+        COUNT(*) AS n_txn,
+        COUNT(DISTINCT DATE_TRUNC('DAY', t.block_timestamp)) AS n_days_active,
+        MIN(
+            DATEDIFF(
+                'days',
+                t.block_timestamp,
+                CURRENT_TIMESTAMP
+            )
+        ) AS days_since_last_txn,
+        COUNT(
+            DISTINCT attribute_value
+        ) AS n_contracts
+    FROM
+        osmosis.core.fact_transactions t
+        LEFT OUTER JOIN osmosis.core.fact_msg_attributes m
+        ON t.tx_id = m.tx_id
+    WHERE
+        t.block_timestamp :: DATE >= CURRENT_DATE - 90
+        AND m.block_timestamp :: DATE >= CURRENT_DATE - 90
+        AND attribute_key = 'module'
+    GROUP BY
+        tx_from
+),
+complex_txs AS (
+    SELECT
+        tx_from AS user_address,
+        COUNT(
+            DISTINCT tx_id
+        ) AS n_complex_txn
+    FROM
+        osmosis.core.fact_transactions
+    WHERE
+        block_timestamp :: DATE >= CURRENT_DATE - 90
+        AND tx_id NOT IN (
+            SELECT
+                tx_id
+            FROM
+                osmosis.core.fact_transfers
+            WHERE
+                transfer_type = 'OSMOSIS'
+        )
+    GROUP BY
+        tx_from
+)
+SELECT
+    b.user_address,
+    n_txn,
+    n_days_active,
+    days_since_last_txn,
+    n_complex_txn,
+    n_contracts
+FROM
+    base_stats b
+    INNER JOIN complex_txs C
+    ON b.user_address = C.user_address

--- a/sql/airdrops/osmosis/airdrop_activity.sql
+++ b/sql/airdrops/osmosis/airdrop_activity.sql
@@ -1,0 +1,12 @@
+SELECT 
+  receiver AS user_address,
+  'osmosis' AS protocol, 
+  currency AS token_contract, 
+  t.project_name AS token_symbol,
+  count(*) AS n_airdrops_claimed, 
+  SUM(amount / POW(10, l.decimal)) AS claimed_token_volume, 
+  SUM((amount / POW(10, l.decimal))*price) AS claimed_usd_volume
+FROM osmosis.core.fact_airdrop l 
+INNER JOIN osmosis.core.dim_tokens t ON l.currency = t.address
+INNER JOIN osmosis.core.dim_prices p ON date_trunc('hour', l.block_timestamp) = p.recorded_at
+GROUP BY user_address, protocol, token_contract, token_symbol

--- a/sql/bags/osmosis/bridge_activity.sql
+++ b/sql/bags/osmosis/bridge_activity.sql
@@ -1,0 +1,70 @@
+WITH ins AS (
+    SELECT
+        sender AS user_address,
+        'IBC' AS bridge_name,
+        currency AS token_contract,
+        t.project_name AS token_symbol,
+        COUNT(*) AS n_in,
+        SUM(amount / POW(10, l.decimal)) AS in_token_volume,
+        SUM((amount / POW(10, l.decimal)) * price) AS in_usd_volume
+    FROM
+        osmosis.core.fact_transfers l
+        INNER JOIN osmosis.core.dim_tokens t
+        ON l.currency = t.address
+        INNER JOIN osmosis.core.dim_prices p
+        ON DATE_TRUNC(
+            'hour',
+            l.block_timestamp
+        ) = p.recorded_at
+        AND t.project_name = p.symbol
+    WHERE
+        block_timestamp :: DATE >= CURRENT_DATE - 90
+        AND transfer_type = 'IBC_TRANSFER_IN'
+    GROUP BY
+        user_address,
+        bridge_name,
+        token_contract,
+        token_symbol
+),
+outs AS (
+    SELECT
+        sender AS user_address,
+        'IBC' AS bridge_name,
+        currency AS token_contract,
+        t.project_name AS token_symbol,
+        COUNT(*) AS n_out,
+        SUM(amount / POW(10, l.decimal)) AS out_token_volume,
+        SUM((amount / POW(10, l.decimal)) * price) AS out_usd_volume
+    FROM
+        osmosis.core.fact_transfers l
+        INNER JOIN osmosis.core.dim_tokens t
+        ON l.currency = t.address
+        INNER JOIN osmosis.core.dim_prices p
+        ON DATE_TRUNC(
+            'hour',
+            l.block_timestamp
+        ) = p.recorded_at
+        AND t.project_name = p.symbol
+    WHERE
+        block_timestamp :: DATE >= CURRENT_DATE - 90
+        AND transfer_type = 'IBC_TRANSFER_OUT'
+    GROUP BY
+        user_address,
+        bridge_name,
+        token_contract,
+        token_symbol
+)
+SELECT
+    user_address,
+    bridge_name,
+    token_contract,
+    token_symbol,
+    n_in,
+    n_out,
+    in_token_volume,
+    in_usd_volume,
+    out_token_volume,
+    out_usd_volume
+FROM
+    ins NATURAL FULL
+    JOIN outs

--- a/sql/bags/osmosis/token_accumulation.sql
+++ b/sql/bags/osmosis/token_accumulation.sql
@@ -1,0 +1,68 @@
+WITH ins AS (
+    SELECT
+        sender AS user_address,
+        currency AS token_contract,
+        t.project_name AS token_symbol,
+        COUNT(*) AS n_xfer_in,
+        SUM(amount / POW(10, l.decimal)) AS xfer_in_token_volume,
+        SUM((amount / POW(10, l.decimal)) * price) AS xfer_in_usd_volume
+    FROM
+        osmosis.core.fact_transfers l
+        INNER JOIN osmosis.core.dim_tokens t
+        ON l.currency = t.address
+        INNER JOIN osmosis.core.dim_prices p
+        ON DATE_TRUNC(
+            'hour',
+            l.block_timestamp
+        ) = p.recorded_at
+        AND t.project_name = p.symbol
+    WHERE
+        block_timestamp :: DATE >= CURRENT_DATE - 90
+        AND (
+            transfer_type = 'IBC_TRANSFER_IN'
+            OR transfer_type = 'OSMOSIS'
+        )
+    GROUP BY
+        user_address,
+        token_contract,
+        token_symbol
+),
+outs AS (
+    SELECT
+        sender AS user_address,
+        currency AS token_contract,
+        t.project_name AS token_symbol,
+        COUNT(*) AS n_xfer_out,
+        SUM(amount / POW(10, l.decimal)) AS xfer_out_token_volume,
+        SUM((amount / POW(10, l.decimal)) * price) AS xfer_out_usd_volume
+    FROM
+        osmosis.core.fact_transfers l
+        INNER JOIN osmosis.core.dim_tokens t
+        ON l.currency = t.address
+        INNER JOIN osmosis.core.dim_prices p
+        ON DATE_TRUNC(
+            'hour',
+            l.block_timestamp
+        ) = p.recorded_at
+        AND t.project_name = p.symbol
+    WHERE
+        block_timestamp :: DATE >= CURRENT_DATE - 90
+        AND transfer_type = 'IBC_TRANSFER_OUT'
+    GROUP BY
+        user_address,
+        token_contract,
+        token_symbol
+)
+SELECT
+    user_address,
+    token_contract,
+    token_symbol,
+    n_xfer_in,
+    n_xfer_out,
+    xfer_in_token_volume,
+    xfer_in_usd_volume,
+    xfer_out_token_volume,
+    xfer_out_usd_volume
+FROM
+    ins NATURAL FULL
+    JOIN outs

--- a/sql/bags/osmosis/token_balance.sql
+++ b/sql/bags/osmosis/token_balance.sql
@@ -1,0 +1,15 @@
+SELECT
+    b.address AS user_address,
+    b.currency AS token_contract,
+    t.project_name AS token_symbol,
+    SUM(balance / POW(10, b.decimal)) AS token_balance
+FROM
+    osmosis.core.fact_daily_balances b
+    INNER JOIN osmosis.core.dim_tokens t
+    ON b.currency = t.address
+WHERE
+    DATE = CURRENT_DATE
+GROUP BY
+    user_address,
+    token_contract,
+    t.project_name

--- a/sql/bags/osmosis/token_balance_tw.sql
+++ b/sql/bags/osmosis/token_balance_tw.sql
@@ -1,0 +1,31 @@
+WITH base AS (
+    SELECT
+        b.date AS DATE,
+        b.address AS user_address,
+        b.currency AS token_contract,
+        t.project_name AS token_symbol,
+        SUM(balance / POW(10, b.decimal)) AS token_balance
+    FROM
+        osmosis.core.fact_daily_balances b
+        INNER JOIN osmosis.core.dim_tokens t
+        ON b.currency = t.address
+    WHERE
+        DATE >= CURRENT_DATE - 90
+    GROUP BY
+        DATE,
+        user_address,
+        token_contract,
+        token_symbol
+)
+SELECT
+    DATE,
+    user_address,
+    token_contract,
+    token_symbol,
+    AVG(token_balance) OVER (
+        ORDER BY
+            DATE ROWS BETWEEN 2 PRECEDING
+            AND CURRENT ROW
+    ) AS token_balance_tw
+FROM
+    base

--- a/sql/defi/osmosis/dex_swaps.sql
+++ b/sql/defi/osmosis/dex_swaps.sql
@@ -1,0 +1,70 @@
+WITH trades_in AS (
+  SELECT
+    trader AS user_address,
+    'osmosis' AS protocol,
+    from_currency AS token_contract,
+    project_name AS token_symbol,
+    COUNT(*) AS n_sells,
+    SUM(from_amount / POW(10, from_decimal)) AS sell_token_volume,
+    SUM((from_amount / POW(10, DECIMAL)) * price) AS sell_usd_volume
+  FROM
+    osmosis.core.fact_swaps s
+    INNER JOIN osmosis.core.dim_tokens t
+    ON from_currency = t.address
+    INNER JOIN osmosis.core.dim_prices p
+    ON DATE_TRUNC(
+      'hour',
+      s.block_timestamp
+    ) = p.recorded_at
+    AND t.project_name = p.symbol
+  WHERE
+    s.block_timestamp :: DATE >= CURRENT_DATE - 90
+  GROUP BY
+    user_address,
+    protocol,
+    token_contract,
+    t.project_name,
+    p.symbol
+),
+trades_out AS (
+  SELECT
+    trader AS user_address,
+    'osmosis' AS protocol,
+    to_currency AS token_contract,
+    project_name AS token_symbol,
+    COUNT(*) AS n_buys,
+    SUM(to_amount / POW(10, TO_DECIMAL)) AS buy_token_volume,
+    SUM((to_amount / POW(10, DECIMAL)) * price) AS buy_usd_volume
+  FROM
+    osmosis.core.fact_swaps s
+    INNER JOIN osmosis.core.dim_tokens t
+    ON from_currency = t.address
+    INNER JOIN osmosis.core.dim_prices p
+    ON DATE_TRUNC(
+      'hour',
+      s.block_timestamp
+    ) = p.recorded_at
+    AND t.project_name = p.symbol
+  WHERE
+    s.block_timestamp :: DATE >= CURRENT_DATE - 90
+  GROUP BY
+    user_address,
+    protocol,
+    token_contract,
+    t.project_name,
+    p.symbol
+)
+SELECT
+  user_address,
+  protocol,
+  token_contract,
+  token_symbol,
+  n_buys,
+  n_sells,
+  buy_token_volume,
+  buy_usd_volume,
+  sell_token_volume,
+  sell_usd_volume
+FROM
+  trades_in NATURAL FULL
+  JOIN trades_out

--- a/sql/defi/osmosis/lp_activity.sql
+++ b/sql/defi/osmosis/lp_activity.sql
@@ -1,0 +1,56 @@
+WITH deps AS (
+  SELECT
+    liquidity_provider_address AS user_address,
+    'osmosis' AS protocol,
+    COUNT(*) AS n_deposits,
+    SUM((amount / POW(10, l.decimal)) * price) AS dep_usd_volume
+  FROM
+    osmosis.core.fact_liquidity_provider_actions l
+    INNER JOIN osmosis.core.dim_tokens t
+    ON l.currency = t.address
+    INNER JOIN osmosis.core.dim_prices p
+    ON DATE_TRUNC(
+      'hour',
+      l.block_timestamp
+    ) = p.recorded_at
+    AND t.project_name = p.symbol
+  WHERE
+    action = 'pool_joined'
+    AND l.block_timestamp >= CURRENT_DATE - 90
+  GROUP BY
+    liquidity_provider_address,
+    protocol
+),
+withdraw AS (
+  SELECT
+    liquidity_provider_address AS user_address,
+    'osmosis' AS protocol,
+    COUNT(*) AS n_withdrawals,
+    SUM((amount / POW(10, l.decimal)) * price) AS wdraw_usd_volume
+  FROM
+    osmosis.core.fact_liquidity_provider_actions l
+    INNER JOIN osmosis.core.dim_tokens t
+    ON l.currency = t.address
+    INNER JOIN osmosis.core.dim_prices p
+    ON DATE_TRUNC(
+      'hour',
+      l.block_timestamp
+    ) = p.recorded_at
+    AND t.project_name = p.symbol
+  WHERE
+    action = 'pool_exited'
+    AND l.block_timestamp >= CURRENT_DATE - 90
+  GROUP BY
+    liquidity_provider_address,
+    protocol
+)
+SELECT
+  user_address,
+  protocol,
+  n_deposits,
+  n_withdrawals,
+  dep_usd_volume,
+  wdraw_usd_volume
+FROM
+  deps NATURAL FULL
+  JOIN withdraw

--- a/sql/governance/osmosis/chain_stakes.sql
+++ b/sql/governance/osmosis/chain_stakes.sql
@@ -1,0 +1,70 @@
+WITH delegates AS (
+    SELECT
+        delegator_address AS user_address,
+        'osmosis' AS protocol,
+        currency AS token_contract,
+        t.project_name AS token_symbol,
+        COUNT(*) AS n_stakes,
+        SUM(amount / POW(10, s.decimal)) AS stake_token_volume,
+        SUM((amount / POW(10, s.decimal)) * price) AS stake_usd_volume
+    FROM
+        osmosis.core.fact_staking s
+        INNER JOIN osmosis.core.dim_tokens t
+        ON s.currency = t.address
+        INNER JOIN osmosis.core.dim_prices p
+        ON DATE_TRUNC(
+            'hour',
+            s.block_timestamp
+        ) = p.recorded_at
+        AND t.project_name = p.symbol
+    WHERE
+        s.block_timestamp :: DATE >= CURRENT_DATE - 90
+        AND action = 'delegate'
+    GROUP BY
+        delegator_address,
+        protocol,
+        currency,
+        token_symbol
+),
+undelegates AS (
+    SELECT
+        delegator_address AS user_address,
+        'osmosis' AS protocol,
+        currency AS token_contract,
+        t.project_name AS token_symbol,
+        COUNT(*) AS n_unstakes,
+        SUM(amount / POW(10, s.decimal)) AS unstake_token_volume,
+        SUM((amount / POW(10, s.decimal)) * price) AS unstake_usd_volume
+    FROM
+        osmosis.core.fact_staking s
+        INNER JOIN osmosis.core.dim_tokens t
+        ON s.currency = t.address
+        INNER JOIN osmosis.core.dim_prices p
+        ON DATE_TRUNC(
+            'hour',
+            s.block_timestamp
+        ) = p.recorded_at
+        AND t.project_name = p.symbol
+    WHERE
+        s.block_timestamp :: DATE >= CURRENT_DATE - 90
+        AND action = 'undelegate'
+    GROUP BY
+        delegator_address,
+        protocol,
+        currency,
+        token_symbol
+)
+SELECT
+    user_address,
+    protocol,
+    token_contract,
+    token_symbol,
+    n_stakes,
+    n_unstakes,
+    stake_token_volume,
+    stake_usd_volume,
+    unstake_usd_volume unstake_token_volume,
+    unstake_usd_volume
+FROM
+    delegates NATURAL FULL
+    JOIN undelegates

--- a/sql/governance/osmosis/gov_votes.sql
+++ b/sql/governance/osmosis/gov_votes.sql
@@ -1,0 +1,11 @@
+SELECT
+    voter AS user_address,
+    'osmosis' AS protocol,
+    COUNT(*) AS n_gov_votes
+FROM
+    osmosis.core.fact_governance_votes
+WHERE
+    block_timestamp :: DATE >= CURRENT_DATE - 90
+GROUP BY
+    voter,
+    protocol


### PR DESCRIPTION
Notes: 

- IBC (bridge to other Cosmos ecosystem blockchains) transfers included in complicated transaction count
- Issue with price table not ingesting data correctly makes some numbers off. PR needed in Osmosis repo to make this prime time ready. Fix in queue, delayed due to current PR freeze
- Airdrop timeframe extended out to all time. Osmosis initial token airdrop & round 2 of Osmo airdrop were the only airdrops on chain. 
- No NFTs on Osmosis
- Governance voting power is by number of tokens staked with validator
- I added a date column to the time weighted average table and used a three day average. Didn't make sense to me without date column. 