### PR TITLE
Correct some comments

### DIFF
--- a/apps/optimism/attestation_contracts/contracts/FlipsideAttestation.sol
+++ b/apps/optimism/attestation_contracts/contracts/FlipsideAttestation.sol
@@ -52,8 +52,6 @@ contract FlipsideAttestation {
      * @param _val The value of the attestation.
      * @param _signature The signature of the attestation.
      * 
-     * Requirements:
-     * - The caller must be the current signer.
      */
     function attest(
           address _about
@@ -81,7 +79,7 @@ contract FlipsideAttestation {
     }
 
     /**
-     * @notice Allows the signer to change the AttestationStation implementation.
+     * @notice Verify that an attestation is signed by the correct signer.
      * @param _about The address of the account to be attested.
      * @param _key The key of the attestation.
      * @param _val The value of the attestation.


### PR DESCRIPTION
- `attest` does not need to be called by the signer.
- `_verifySignature` does not change anything.

Just being a pedantic tech writer.